### PR TITLE
Change server tick event behaviour

### DIFF
--- a/src/com/minecrafttas/tasmod/mixin/events/HookMinecraftServer.java
+++ b/src/com/minecrafttas/tasmod/mixin/events/HookMinecraftServer.java
@@ -19,9 +19,13 @@ public class HookMinecraftServer {
 
 	/**
 	 * Triggers an Event in {@link CommonTASmod#onServerTick(Minecraft)} before every tick
+	 * 
+	 * IMPLEMENTATION NOTICE:
+	 * The run() method is the run method for the entire server. This mixin catches when tick() is called and then triggers an event. It is very important
+	 * not to inject into the head of tick() since it can be cancelled by the integrated server while the server is paused (eg. the escape menu is open).
 	 * @param ci Callback Info
 	 */
-	@Inject(method = "tick", at = @At("HEAD"))
+	@Inject(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;tick()V"))
 	public void hookRunTickEvent(CallbackInfo ci) {
 		CommonTASmod.instance.onServerTick((MinecraftServer) (Object) this);
 	}


### PR DESCRIPTION
Previously the tick would not be called with the integrated server paused, now it will always call when a tick "should" run.