### PR TITLE
Correct the logger message in two places

### DIFF
--- a/src/com/minecrafttas/tasmod/CommonTASmod.java
+++ b/src/com/minecrafttas/tasmod/CommonTASmod.java
@@ -24,7 +24,7 @@ public class CommonTASmod {
 	 */
 	@EventHandler
 	public void onPreInit(FMLPreInitializationEvent e) {
-		TASmod.LOGGER.debug("Common TASmod Init Phase");
+		TASmod.LOGGER.debug("Common TASmod Preinit Phase");
 	}
 	
 	/**
@@ -49,7 +49,7 @@ public class CommonTASmod {
 	 * @param mcserver Instance of Minecraft Server
 	 */
 	public void onServerTick(MinecraftServer mcserver) {
-		TASmod.LOGGER.debug("TASmod Server Tick Handle");
+		TASmod.LOGGER.debug("Server Tick");
 	}
 	
 }


### PR DESCRIPTION
* The preinit phase incorrectly said 'Common TASmod Init Phase'.
* The server tick handler messages was changed to 'Server Tick' so it fits with the client one.