### PR TITLE
Fix a freeze when closing minecraft without closing the server

### DIFF
--- a/src/com/minecrafttas/tasmod/CommonTASmod.java
+++ b/src/com/minecrafttas/tasmod/CommonTASmod.java
@@ -113,7 +113,7 @@ public class CommonTASmod {
 	 * @param mcserver Instance of Minecraft Server
 	 */
 	public void onServerTick(MinecraftServer mcserver) {
-		TASmod.LOGGER.debug("Server Tick");
+		TASmod.LOGGER.trace("Server Tick");
 	}
 
 	/**
@@ -125,11 +125,11 @@ public class CommonTASmod {
 	 * @param mcserver Instance of Minecraft Server
 	 */
 	public void onServerPostTick(MinecraftServer mcserver) {
-		TASmod.LOGGER.debug("Server Post Tick");
+		TASmod.LOGGER.trace("Server Post Tick");
 		/* Update tick sync */
-		TASmod.LOGGER.debug("Updating tick sync post tick");
+		TASmod.LOGGER.trace("Updating tick sync post tick");
 		TickSyncServer.serverPostTick();
-		TASmod.LOGGER.debug("Tick sync was updated post tick");
+		TASmod.LOGGER.trace("Tick sync was updated post tick");
 	}
 	
 }

--- a/src/com/minecrafttas/tasmod/client/ClientTASmod.java
+++ b/src/com/minecrafttas/tasmod/client/ClientTASmod.java
@@ -129,11 +129,11 @@ public class ClientTASmod extends CommonTASmod {
 	 * @param mc Instance of Minecraft
 	 */
 	public void onClientTick(Minecraft mc) {
-		TASmod.LOGGER.debug("Client Tick");
+		TASmod.LOGGER.trace("Client Tick");
 		/* Update virtual mouse */
-		TASmod.LOGGER.debug("Updating virtual mouse DX and DY");
+		TASmod.LOGGER.trace("Updating virtual mouse DX and DY");
 		VirtualMouse.poll();
-		TASmod.LOGGER.debug("Virtual mouse updated pre tick");
+		TASmod.LOGGER.trace("Virtual mouse updated pre tick");
 	}
 	
 	/**
@@ -146,11 +146,11 @@ public class ClientTASmod extends CommonTASmod {
 	 * @param mc Instance of Minecraft
 	 */
 	public void onClientPostTick(Minecraft mc) {
-		TASmod.LOGGER.debug("Client Post Tick");
+		TASmod.LOGGER.trace("Client Post Tick");
 		/* Update tick sync */
-		TASmod.LOGGER.debug("Updating tick sync post tick");
+		TASmod.LOGGER.trace("Updating tick sync post tick");
 		TickSyncClient.clientPostTick(mc);
-		TASmod.LOGGER.debug("Tick sync was updated post tick");
+		TASmod.LOGGER.trace("Tick sync was updated post tick");
 	}
 	
 	/**
@@ -165,14 +165,14 @@ public class ClientTASmod extends CommonTASmod {
 	public void onClientRender(RenderGameOverlayEvent e) {
 		if (e.getType() != ElementType.TEXT) return; // Only render on this certain event
 		
-		TASmod.LOGGER.debug("Client Render Loop");
+		TASmod.LOGGER.trace("Client Render Loop");
 		if (Tool.TOOLS /* Whether tools should load or not */) {
 			/* Render mouse and keyboard */
-			TASmod.LOGGER.debug("Rendering keyboard and mouse");
+			TASmod.LOGGER.trace("Rendering keyboard and mouse");
 			final ScaledResolution res = e.getResolution();
 			VirtualKeyboard.render(res.getScaledWidth(), res.getScaledHeight());
 			VirtualMouse.render(res.getScaledWidth(), res.getScaledHeight());
-			TASmod.LOGGER.debug("Keyboard and mouse were rendered");
+			TASmod.LOGGER.trace("Keyboard and mouse were rendered");
 		}
 	}
 	

--- a/src/com/minecrafttas/tasmod/client/ClientTASmod.java
+++ b/src/com/minecrafttas/tasmod/client/ClientTASmod.java
@@ -10,6 +10,7 @@ import com.minecrafttas.tasmod.client.ticks.TimerMod;
 import com.minecrafttas.tasmod.client.virtualinputs.VirtualKeyboard;
 import com.minecrafttas.tasmod.client.virtualinputs.VirtualMouse;
 import com.minecrafttas.tasmod.exceptions.ClientAlreadyRunningException;
+import com.minecrafttas.tasmod.mixin.client.events.HookMinecraft;
 import com.minecrafttas.tasmod.networking.Client;
 
 import net.minecraft.client.Minecraft;
@@ -108,6 +109,27 @@ public class ClientTASmod extends CommonTASmod {
 	@SubscribeEvent
 	public void onClientDisconnect(ClientDisconnectionFromServerEvent e) {
 		TASmod.LOGGER.debug("TASmod Disconnect Server Phase");
+		/* Kill the custom client thread */
+		try {
+			TASmod.LOGGER.debug("Trying to kill the custom tasmod client");
+			Client.killClient(); // this will kill the client if it is running
+			TASmod.LOGGER.debug("Successfully killed the custom tasmod client without any unexpected issues");
+		} catch (IOException exception) {
+			TASmod.LOGGER.error("Exception thrown trying to kill the custom TASmod client!");
+			TASmod.LOGGER.error(exception);
+		}
+	}
+	
+	/**
+	 * Uninitialize the TASmod when shutting down the Minecraft applocation.
+	 * This will kill the custom TASmod client on a seperate thread
+	 * 
+	 * IMPLEMENTATION NOTICE:
+	 * Trace: net.minecraft.client.Minecraft.shutdownMinecraftApplet()V
+	 * Mixin: {@link HookMinecraft#hookShutdownMinecraftApplet()}
+	 */
+	public void onClientShutdown() {
+		TASmod.LOGGER.debug("TASmod Shutdown Client Phase");
 		/* Kill the custom client thread */
 		try {
 			TASmod.LOGGER.debug("Trying to kill the custom tasmod client");

--- a/src/com/minecrafttas/tasmod/client/ClientTASmod.java
+++ b/src/com/minecrafttas/tasmod/client/ClientTASmod.java
@@ -109,19 +109,11 @@ public class ClientTASmod extends CommonTASmod {
 	@SubscribeEvent
 	public void onClientDisconnect(ClientDisconnectionFromServerEvent e) {
 		TASmod.LOGGER.debug("TASmod Disconnect Server Phase");
-		/* Kill the custom client thread */
-		try {
-			TASmod.LOGGER.debug("Trying to kill the custom tasmod client");
-			Client.killClient(); // this will kill the client if it is running
-			TASmod.LOGGER.debug("Successfully killed the custom tasmod client without any unexpected issues");
-		} catch (IOException exception) {
-			TASmod.LOGGER.error("Exception thrown trying to kill the custom TASmod client!");
-			TASmod.LOGGER.error(exception);
-		}
+		shutdownClient();
 	}
 	
 	/**
-	 * Uninitialize the TASmod when shutting down the Minecraft applocation.
+	 * Uninitialize the TASmod when shutting down the Minecraft application.
 	 * This will kill the custom TASmod client on a seperate thread
 	 * 
 	 * IMPLEMENTATION NOTICE:
@@ -130,6 +122,13 @@ public class ClientTASmod extends CommonTASmod {
 	 */
 	public void onClientShutdown() {
 		TASmod.LOGGER.debug("TASmod Shutdown Client Phase");
+		shutdownClient();
+	}
+	
+	/**
+	 * Attempts to shutdown the TASmod client
+	 */
+	private void shutdownClient() {
 		/* Kill the custom client thread */
 		try {
 			TASmod.LOGGER.debug("Trying to kill the custom tasmod client");

--- a/src/com/minecrafttas/tasmod/client/virtualinputs/VirtualKeyboard.java
+++ b/src/com/minecrafttas/tasmod/client/virtualinputs/VirtualKeyboard.java
@@ -92,7 +92,7 @@ public class VirtualKeyboard {
 	 * In the case of this virtual keyboard, it also updates the internal keyboard replica which is being used by isKeyDown
 	 */
 	public static boolean next() {
-		TASmod.LOGGER.debug("Processing next keyboard event...");
+		TASmod.LOGGER.trace("Processing next keyboard event...");
 		boolean hasNext;
 		
 		/* Input Source 1: The actual keyboard */
@@ -106,7 +106,7 @@ public class VirtualKeyboard {
 		
 		/* Input Source 2 (example): The playback file. Add custom input packet sources here into an else block and update hasNext for future input sources. */
 		
-		TASmod.LOGGER.debug("Processed next keyboard event");
+		TASmod.LOGGER.trace("Processed next keyboard event");
 		if (hasNext && /* Fix F11 */ VirtualKeyboard.eventKeyCode != Keyboard.KEY_F11) VirtualKeyboard.keyStates[VirtualKeyboard.eventKeyCode] = VirtualKeyboard.eventKeyState; // Update the keyboard replica
 		return hasNext && /* Fix F11 */ VirtualKeyboard.eventKeyCode != Keyboard.KEY_F11;
 	}

--- a/src/com/minecrafttas/tasmod/client/virtualinputs/VirtualMouse.java
+++ b/src/com/minecrafttas/tasmod/client/virtualinputs/VirtualMouse.java
@@ -79,7 +79,7 @@ public class VirtualMouse {
 	 * In the case of this virtual mouse, it also updates the internal mouse replica which is being used by isButtonDown and getX,getY
 	 */
 	public static boolean next() {
-		TASmod.LOGGER.debug("Processing next mouse event...");
+		TASmod.LOGGER.trace("Processing next mouse event...");
 		boolean hasNext;
 		
 		/* Input Source 1: The actual mouse */
@@ -94,7 +94,7 @@ public class VirtualMouse {
 		}
 		/* Input Source 2 (example): The playback file. Add custom input packet sources here into an else block and update hasNext for future input sources. */
 		
-		TASmod.LOGGER.debug("Processed next mouse event");
+		TASmod.LOGGER.trace("Processed next mouse event");
 		if (hasNext) VirtualMouse.buttonStates[VirtualMouse.eventButton+256] = VirtualMouse.eventButtonState; // Update the keyboard replica
 		return hasNext;
 	}

--- a/src/com/minecrafttas/tasmod/mixin/client/events/HookMinecraft.java
+++ b/src/com/minecrafttas/tasmod/mixin/client/events/HookMinecraft.java
@@ -37,4 +37,12 @@ public class HookMinecraft {
 		ClientTASmod.instance.onClientPostTick((Minecraft) (Object) this);
 	}
 	
+	/**
+	 * Triggers an Event in {@link ClientTASmod#onClientShutdown()} when the Minecraft Client is shutting down
+	 * @param ci Callback Info
+	 */
+	@Inject(method = "shutdownMinecraftApplet", at = @At("HEAD"))
+	public void hookShutdownMinecraftApplet(CallbackInfo ci) {
+		ClientTASmod.instance.onClientShutdown();
+	}
 }

--- a/src/com/minecrafttas/tasmod/networking/CommonHandler.java
+++ b/src/com/minecrafttas/tasmod/networking/CommonHandler.java
@@ -47,7 +47,7 @@ public class CommonHandler {
 					outputStream.writeInt(packetData.length);
 					outputStream.write(packetData);
 					outputStream.flush();
-					TASmod.LOGGER.debug("Sent a " + packet.getClass().getSimpleName() + " to the socket.");
+					TASmod.LOGGER.trace("Sent a " + packet.getClass().getSimpleName() + " to the socket.");
 				}
 			} catch (Exception exception) {
 				// This exception is already logged by the thread one layer above
@@ -67,7 +67,7 @@ public class CommonHandler {
 			// Deserialize and run the packet
 			packet = PacketSerializer.deserialize(packetBuf);
 			packet.handle(); 
-			TASmod.LOGGER.debug("Handled a " + packet.getClass().getSimpleName() + " from the socket.");
+			TASmod.LOGGER.trace("Handled a " + packet.getClass().getSimpleName() + " from the socket.");
 		}
 	}
 	


### PR DESCRIPTION
# Problem
When in a world, closing the minecraft client will freeze the game. Reason is that the TASmod Client didn't shut down properly, since it only shuts down when closing the integrated server.
# Solution
Added a hook to `Minecraft.shutdownMinecraftApplet(`) and implementation in `ClientTASmod#onClientShutdown()`. Basically a copy of `ClientTAsmod#onClientDisconnect()` where the TASmodClient is normally shut down
# Additional changes
To avoid spammy debug level log messages, I changed some log messages to trace. This can easily be reverted.